### PR TITLE
Update guzzle version to ~3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	],
 	"require" : {
 		"php" : ">=5.4",
-		"guzzle/guzzle" : "3.8.*",
+		"guzzle/guzzle" : "~3.8",
 		"google/apiclient": "1.0.4-beta"
 	},
 	"require-dev" : {


### PR DESCRIPTION
Allows using the library together with other libraries that require
guzzle 3.9